### PR TITLE
feat: add database SQLite integration with typeorm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 
 # Application
 /uploads
+/src/database/*.sqlite

--- a/ormconfig.json
+++ b/ormconfig.json
@@ -1,0 +1,13 @@
+{
+  "type": "sqlite",
+  "database": "./src/database/database.sqlite",
+  "migrations": [
+    "./src/database/migrations/*.ts"
+  ],
+  "entities": [
+    "./src/models/*.ts"
+  ],
+  "cli": {
+    "migrationsDir": "./src/database/migrations"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A REST API for Happy applications.",
   "main": "index.js",
   "scripts": {
-    "dev": "ts-node-dev --transpile-only --ignore-watch node_modules src/server.ts"
+    "dev": "ts-node-dev --transpile-only --ignore-watch node_modules src/server.ts",
+    "typeorm": "npx ts-node-dev ./node_modules/typeorm/cli.js"
   },
   "keywords": [],
   "author": "Lucas Vasconcelos",
@@ -13,7 +14,9 @@
     "@types/cors": "^2.8.8",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "express-async-errors": "^3.1.1"
+    "express-async-errors": "^3.1.1",
+    "sqlite3": "^5.0.0",
+    "typeorm": "^0.2.28"
   },
   "devDependencies": {
     "@types/express": "^4.17.8",

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -1,0 +1,3 @@
+import { createConnection } from 'typeorm';
+
+createConnection();

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import 'express-async-errors';
 import cors from 'cors';
 
 import errorHandler from './errors/handler';
+import './database/connection';
 
 const app = express();
 


### PR DESCRIPTION
For now it should be enough using SQLite database as main storage
and TypeORM to map the entities.