### PR TITLE
feat: add support to store orphanage images

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-async-errors": "^3.1.1",
+    "multer": "^1.4.2",
     "sqlite3": "^5.0.0",
     "typeorm": "^0.2.28",
     "yup": "^0.29.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.8",
+    "@types/multer": "^1.4.4",
     "ts-node-dev": "^1.0.0-pre.63",
     "typescript": "^4.0.3"
   }

--- a/src/config/upload.ts
+++ b/src/config/upload.ts
@@ -1,0 +1,13 @@
+import multer from 'multer';
+import path from 'path';
+
+export default {
+  storage: multer.diskStorage({
+    destination: path.join(__dirname, '..', '..', 'uploads'),
+    filename: (request, file, callback) => {
+      const fileName = `${Date.now()}-${file.originalname}`;
+
+      callback(null, fileName);
+    }
+  })
+};

--- a/src/database/migrations/1602643327199-create_images.ts
+++ b/src/database/migrations/1602643327199-create_images.ts
@@ -1,0 +1,44 @@
+import {MigrationInterface, QueryRunner, Table} from "typeorm";
+
+
+export class createImages1602643327199 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(new Table({
+      name: 'image',
+      columns: [
+        {
+          name: 'id',
+          type: 'integer',
+          unsigned: true,
+          isPrimary: true,
+          isGenerated: true,
+          generationStrategy: 'increment'
+        },
+        {
+          name: 'path',
+          type: 'varchar',
+        },
+        {
+          name: 'orphanage_id',
+          type: 'integer'
+        }
+      ],
+      foreignKeys: [
+        {
+          name: 'ImageOrphanage',
+          columnNames: ['orphanage_id'],
+          referencedTableName: 'orphanage',
+          referencedColumnNames: ['id'],
+          onUpdate: 'CASCADE',
+          onDelete: 'CASCADE'
+        }
+      ]
+    }))
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('images');
+  }
+
+}

--- a/src/models/Image.ts
+++ b/src/models/Image.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+import Orphanage from './Orphanage';
+
+@Entity('image')
+export default class Image {
+
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column()
+  path: string;
+
+  @ManyToOne(() => Orphanage, orphanage => orphanage.images)
+  @JoinColumn({ name: 'orphanage_id' })
+  orphanage: Orphanage;
+}

--- a/src/models/Orphanage.ts
+++ b/src/models/Orphanage.ts
@@ -1,4 +1,6 @@
-import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany, JoinColumn } from 'typeorm';
+
+import Image from './Image';
 
 
 @Entity('orphanage')
@@ -26,5 +28,15 @@ export default class Orphanage {
   
   @Column()
   open_on_weekends: boolean;
+
+  @OneToMany(
+    () => Image,
+    image => image.orphanage,
+    {
+      cascade: ['insert', 'update']
+    }
+  )
+  @JoinColumn({ name: 'orphanage_id'})
+  images: Image[];
 
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,12 +1,15 @@
 import { Router } from 'express';
+import multer from 'multer';
 
 import OrphanagesController from './controllers/OrphanagesController';
+import uploadConfig from './config/upload';
 
 
 const routes = Router();
+const upload = multer(uploadConfig);
 
 routes.get('/orphanages', OrphanagesController.index);
 routes.get('/orphanages/:id', OrphanagesController.show);
-routes.post('/orphanages', OrphanagesController.create);
+routes.post('/orphanages', upload.array('images'), OrphanagesController.create);
 
 export default routes;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import 'express-async-errors';
+import path from 'path';
 import cors from 'cors';
 
 import errorHandler from './errors/handler';
@@ -12,6 +13,7 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 app.use(routes);
+app.use('/uploads', express.static(path.join(__dirname, '..', 'uploads')));
 app.use(errorHandler);
 
 app.listen(3333);

--- a/src/views/ImageView.ts
+++ b/src/views/ImageView.ts
@@ -1,0 +1,14 @@
+import Image from "../models/Image";
+
+export default {
+  render(image: Image) {
+    return {
+      id: image.id,
+      url: `http://192.168.0.17:3333/uploads/${image.path}`
+    };
+  },
+
+  renderMany(images: Image[]) {
+    return images.map(image => this.render(image));
+  }
+};

--- a/src/views/OrphanageView.ts
+++ b/src/views/OrphanageView.ts
@@ -1,4 +1,5 @@
 import Orphanage from '../models/Orphanage';
+import imagesView from './ImageView';
 
 
 export default {
@@ -12,6 +13,7 @@ export default {
       instructions: orphanage.instructions,
       opening_hours: orphanage.opening_hours,
       open_on_weekends: orphanage.open_on_weekends,
+      images: imagesView.renderMany(orphanage.images),
     };
   },
 


### PR DESCRIPTION
Add support to store multiple images of orphanages.
The images are stored under ./uploads/ folder and their names
are stored in database.