### PR TITLE
feat: add pending approval field to orphanages

### DIFF
--- a/src/database/migrations/1603043802457-add_pending_approval_column.ts
+++ b/src/database/migrations/1603043802457-add_pending_approval_column.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class addPendingApprovalColumn1603043802457 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn("orphanage", new TableColumn({
+            name: "pending_approval",
+            type: "boolean",
+            default: "true"
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}

--- a/src/models/Orphanage.ts
+++ b/src/models/Orphanage.ts
@@ -29,6 +29,9 @@ export default class Orphanage {
   @Column()
   open_on_weekends: boolean;
 
+  @Column()
+  pending_approval: boolean;
+
   @OneToMany(
     () => Image,
     image => image.orphanage,

--- a/src/views/OrphanageView.ts
+++ b/src/views/OrphanageView.ts
@@ -13,6 +13,7 @@ export default {
       instructions: orphanage.instructions,
       opening_hours: orphanage.opening_hours,
       open_on_weekends: orphanage.open_on_weekends,
+      pending_approval: orphanage.pending_approval,
       images: imagesView.renderMany(orphanage.images),
     };
   },


### PR DESCRIPTION
Add the pending_approval field when creating an orphanage.
By default, all orphanages are created with pending approval
status setted to true. These orphanages are not retrieved
when using (GET) /orphanages route, but it is retrieved
using (GET) /orphanages/:id